### PR TITLE
Changed URL (Caregivers Alliance Limited to Mindfull Community)

### DIFF
--- a/_wellness/Resources/Resources for Caregivers.md
+++ b/_wellness/Resources/Resources for Caregivers.md
@@ -12,7 +12,7 @@ variant: tiptap
 </p>
 </li>
 <li>
-<p><a href="https://www.cal.org.sg/" rel="noopener noreferrer nofollow" target="_blank">Caregivers Alliance Limited</a>
+<p><a href="https://www.mindfull.org.sg/" rel="noopener noreferrer nofollow" target="_blank">Mindfull Community</a>
 </p>
 </li>
 <li>


### PR DESCRIPTION
Changed of URL from CAL to Mindfull Community. Mindfull Community was formerly known as Caregivers Alliance Limited